### PR TITLE
JSC-4: Auto-increment PR numbers in create-pr script

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -76,23 +76,27 @@ git commit -m "docs(jsc-1): update README with dark mode info"
 git push origin jsc-{номер}-{описание}
 ```
 
-2. Создайте Pull Request автоматически:
+2. Создайте Pull Request автоматически с помощью скрипта:
+```bash
+# Автоматически определит JSC номер из имени ветки
+./scripts/create-pr.sh "Add dark mode support"
+
+# Или укажите номер вручную
+./scripts/create-pr.sh 5 "Add dark mode support"
+```
+
+Скрипт автоматически:
+- ✅ Извлечёт номер JSC из имени ветки (если есть)
+- ✅ Предложит следующий доступный номер (если нет в ветке)
+- ✅ Создаст PR с правильным заголовком `JSC-N: Description`
+- ✅ Добавит `Closes #N` в описание
+
+Или используйте `gh` напрямую:
 ```bash
 gh pr create --title "JSC-{номер}: {Описание}" \
   --body "Closes #{номер}" \
   --base main
 ```
-
-Или используйте скрипт:
-```bash
-./scripts/create-pr.sh "JSC-{номер}: Title" "Description of changes"
-```
-
-3. В PR укажите:
-   - Заголовок: `JSC-{номер}: {Описание}`
-   - Ссылку на issue: `Closes #N`
-   - Описание изменений
-   - Скриншоты (если применимо)
 
 ### 5. Мерж
 

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 # Quick PR creation script for jira-smart-copy project
-# Usage: ./scripts/create-pr.sh "Title of PR" "Description"
+# Usage: ./scripts/create-pr.sh "Description of changes"
+# Or:    ./scripts/create-pr.sh [issue-number] "Description of changes"
 
-TITLE="$1"
-DESCRIPTION="$2"
+DESCRIPTION="$1"
+ISSUE_NUM=""
 CURRENT_BRANCH=$(git branch --show-current)
 
-if [ -z "$TITLE" ]; then
-    echo "Error: PR title is required"
-    echo "Usage: $0 \"Title\" \"Description\""
-    exit 1
+# Check if first argument is a number (manual issue number)
+if [[ "$1" =~ ^[0-9]+$ ]]; then
+    ISSUE_NUM="$1"
+    DESCRIPTION="$2"
 fi
 
 if [ "$CURRENT_BRANCH" = "main" ]; then
@@ -17,16 +18,45 @@ if [ "$CURRENT_BRANCH" = "main" ]; then
     exit 1
 fi
 
-# Extract issue number from branch name (e.g., jsc-1-feature -> 1)
-ISSUE_NUM=$(echo "$CURRENT_BRANCH" | grep -oP 'jsc-\K\d+')
-
-BODY="$DESCRIPTION"
-
-if [ -n "$ISSUE_NUM" ]; then
-    BODY="$BODY
-
-Closes #$ISSUE_NUM"
+# Try to extract issue number from branch name if not provided
+if [ -z "$ISSUE_NUM" ]; then
+    ISSUE_NUM=$(echo "$CURRENT_BRANCH" | grep -oE 'jsc-[0-9]+' | grep -oE '[0-9]+')
 fi
+
+# If still no issue number, get the next available one
+if [ -z "$ISSUE_NUM" ]; then
+    echo "📋 Fetching latest PR/issue numbers..."
+    LAST_PR=$(gh pr list --state all --json number --jq 'map(.number) | max // 0')
+    LAST_ISSUE=$(gh issue list --state all --json number --jq 'map(.number) | max // 0')
+    LAST_NUM=$((LAST_PR > LAST_ISSUE ? LAST_PR : LAST_ISSUE))
+    ISSUE_NUM=$((LAST_NUM + 1))
+    
+    echo "⚠️  No JSC number found in branch name"
+    echo "📌 Suggested branch name: jsc-${ISSUE_NUM}-your-feature-name"
+    echo "🔢 Using JSC-${ISSUE_NUM} for this PR"
+    echo ""
+    read -p "Continue with JSC-${ISSUE_NUM}? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 1
+    fi
+fi
+
+if [ -z "$DESCRIPTION" ]; then
+    echo "Error: Description is required"
+    echo "Usage: $0 \"Description of changes\""
+    echo "   Or: $0 [issue-number] \"Description of changes\""
+    exit 1
+fi
+
+TITLE="JSC-${ISSUE_NUM}: ${DESCRIPTION}"
+BODY="Closes #${ISSUE_NUM}"
+
+echo "Creating PR:"
+echo "  Title: $TITLE"
+echo "  Branch: $CURRENT_BRANCH → main"
+echo ""
 
 gh pr create \
     --title "$TITLE" \


### PR DESCRIPTION
## Changes

- Script now automatically detects the next available JSC number
- Extracts issue number from branch name pattern `jsc-N-feature`
- Falls back to fetching `max(PR numbers, issue numbers) + 1`
- Interactive confirmation when auto-generating number
- Simplified usage: just pass description instead of full title

## New Usage

```bash
# Auto-detect JSC number from branch name or generate next
./scripts/create-pr.sh "Add dark mode support"

# Or specify issue number manually
./scripts/create-pr.sh 10 "Add dark mode support"
```

## Features

- ✅ Validates you're not on main branch
- ✅ Extracts JSC-N from branch name automatically
- ✅ Queries GitHub API for latest PR/issue numbers
- ✅ Interactive confirmation for auto-generated numbers
- ✅ Creates PR with proper `JSC-N: Description` format
- ✅ Auto-adds `Closes #N` to PR body

Closes #4